### PR TITLE
Fix spelling of overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ Only specified behaviors registered if list defined:
 
 - __L\_ADDITIVE__, __R\_ADDITIVE__
 
-    Hashes merged, arrays joined, undefined scalars overrided. Left and right
+    Hashes merged, arrays joined, undefined scalars overridden. Left and right
     precedence.
 
 - __L\_OVERRIDE__, __R\_OVERRIDE__
 
-    Hashes merged, arrays and scalars overrided. Left and right precedence.
+    Hashes merged, arrays and scalars overridden. Left and right precedence.
 
 - __L\_REPLACE__, __R\_REPLACE__
 

--- a/lib/Hash/Merge/Extra.pm
+++ b/lib/Hash/Merge/Extra.pm
@@ -188,12 +188,12 @@ Only specified behaviors registered if list defined:
 
 =item B<L_ADDITIVE>, B<R_ADDITIVE>
 
-Hashes merged, arrays joined, undefined scalars overrided. Left and right
+Hashes merged, arrays joined, undefined scalars overridden. Left and right
 precedence.
 
 =item B<L_OVERRIDE>, B<R_OVERRIDE>
 
-Hashes merged, arrays and scalars overrided. Left and right precedence.
+Hashes merged, arrays and scalars overridden. Left and right precedence.
 
 =item B<L_REPLACE>, B<R_REPLACE>
 


### PR DESCRIPTION
Hey,

While preparing this package for inclusion in Debian (it is a new dependency of Request Tracker which I am involved in looking after in Debian), one of our tools highlighted that overrided is used when it should probably be overridden.

Cheers,
Andrew